### PR TITLE
Replace IconShield with supported IconSafe

### DIFF
--- a/apps/web/src/components/Game/ActionPanel.vue
+++ b/apps/web/src/components/Game/ActionPanel.vue
@@ -145,12 +145,12 @@
 import { ref, computed } from 'vue'
 import { Button, Modal, Message } from '@arco-design/web-vue'
 import { 
-  IconThumbUp, 
-  IconUser, 
-  IconMoon, 
+  IconThumbUp,
+  IconUser,
+  IconMoon,
   IconClockCircle,
   IconEye,
-  IconShield,
+  IconSafe,
   IconFire,
   IconHeart,
   IconMore
@@ -282,7 +282,7 @@ function getActionIcon(type: string): any {
     night_action: IconMoon,
     special: IconMore,
     seer_check: IconEye,
-    guard_protect: IconShield,
+    guard_protect: IconSafe,
     witch_poison: IconFire,
     witch_heal: IconHeart,
     werewolf_kill: IconMore, // Fallback since sword doesn't exist

--- a/apps/web/src/views/Auth/Register.vue
+++ b/apps/web/src/views/Auth/Register.vue
@@ -128,14 +128,14 @@
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import {
-  AForm,
-  AFormItem,
-  AInput,
-  AInputPassword,
-  AButton,
-  AIcon,
-  ACheckbox,
-  AAlert,
+  Form as AForm,
+  FormItem as AFormItem,
+  Input as AInput,
+  InputPassword as AInputPassword,
+  Button as AButton,
+  Icon as AIcon,
+  Checkbox as ACheckbox,
+  Alert as AAlert,
   Message
 } from '@arco-design/web-vue'
 import type { FieldRule } from '@arco-design/web-vue/es/form/interface'

--- a/apps/web/src/views/Game/GameRoom.vue
+++ b/apps/web/src/views/Game/GameRoom.vue
@@ -172,13 +172,13 @@
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import {
-  AButton,
-  AIcon,
-  AAlert,
-  ATextarea,
-  ARadioGroup,
-  ARadio,
-  ASpin,
+  Button as AButton,
+  Icon as AIcon,
+  Alert as AAlert,
+  Textarea as ATextarea,
+  RadioGroup as ARadioGroup,
+  Radio as ARadio,
+  Spin as ASpin,
   Message,
   Modal
 } from '@arco-design/web-vue'

--- a/apps/web/src/views/NotFound.vue
+++ b/apps/web/src/views/NotFound.vue
@@ -3,7 +3,7 @@
     <div class="not-found-content">
       <div class="error-visual">
         <div class="error-code">404</div>
-        <IconFrown class="error-icon" />
+        <IconFaceFrownFill class="error-icon" />
       </div>
       
       <h1 class="error-title">页面未找到</h1>
@@ -28,7 +28,7 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
 import { Button } from '@arco-design/web-vue'
-import { IconFrown, IconHome, IconLeft } from '@arco-design/web-vue/es/icon'
+import { IconFaceFrownFill, IconHome, IconLeft } from '@arco-design/web-vue/es/icon'
 
 const router = useRouter()
 


### PR DESCRIPTION
## Summary
- fix build error by swapping nonexistent `IconShield` for `IconSafe` in action panel
- replace unsupported `IconFrown` with `IconFaceFrownFill` and alias Arco components to their actual exports

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token <)*
- `npm run type-check` *(fails: Property 'request' is private and 'apiService' not defined, etc.)*
- `npm run lint:style` *(fails: ConfigurationError: No configuration provided for App.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68a04a3095648327833bd8d0943893e6

## Sourcery 摘要

修复构建错误，方法是更新不再支持的图标引用，并使 Arco 组件导入与实际的命名导出保持一致。

Bug 修复：
- 将不存在的 IconShield 替换为 IconSafe，用于守卫保护操作。
- 在 404 未找到视图中，将不再支持的 IconFrown 替换为 IconFaceFrownFill。

增强：
- 在 Register.vue 和 GameRoom.vue 中，将 Arco Design Web Vue 组件别名为它们实际的导出（例如，将 Form 别名为 AForm，将 Input 别名为 AInput）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix build errors by updating unsupported icon references and aligning Arco component imports with actual named exports.

Bug Fixes:
- Replace nonexistent IconShield with IconSafe for guard protect action
- Swap unsupported IconFrown for IconFaceFrownFill in the 404 NotFound view

Enhancements:
- Alias Arco Design Web Vue components to their actual exports (e.g., Form as AForm, Input as AInput) in Register.vue and GameRoom.vue

</details>